### PR TITLE
Fix/reusable grid

### DIFF
--- a/packages/mars-theme/src/components/blog-header.js
+++ b/packages/mars-theme/src/components/blog-header.js
@@ -29,14 +29,17 @@ const Title = styled.h1`
   font-size: 1.875rem;
   font-weight: 200;
   margin: 0;
-  margin-bottom: 1rem;
+  margin-bottom: 20px;
 `;
 
 const Description = styled.h4`
-  margin: 0;
+  margin-bottom: 30px;
   color: var(--color-dark-grey);
   font-size: 1.125rem;
   line-height: 1.875rem;
   font-weight: 200;
   text-transform: initial;
+  @media screen and (min-width: ${SMALL_ENDPOINT}) {
+    margin-bottom: 60px;
+  }
 `;

--- a/packages/mars-theme/src/components/blog-header.js
+++ b/packages/mars-theme/src/components/blog-header.js
@@ -1,16 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect, styled } from 'frontity';
-import { SMALL_ENDPOINT, MEDIUM_ENDPOINT } from './heplers/css-endpoints';
+import { SMALL_ENDPOINT } from './heplers/css-endpoints';
 
 const BlogHeader = ({ state }) => {
   return (
-    <Wrapper>
-      <Title>{state.frontity.title}</Title>
-      <Description>
-        <b>{state.frontity.description}</b>
-      </Description>
-    </Wrapper>
+    <div className="row">
+      <div className="column small-12 medium-10 large-8">
+        <Title>{state.frontity.title}</Title>
+        <Description>
+          <b>{state.frontity.description}</b>
+        </Description>
+      </div>
+    </div>
   );
 };
 
@@ -19,20 +21,6 @@ export default connect(BlogHeader);
 BlogHeader.propTypes = {
   state: PropTypes.object,
 };
-
-const Wrapper = styled.div`
-  width: 100%;
-  padding: 1.5rem 1rem;
-  @media screen and (min-width: ${SMALL_ENDPOINT}) {
-    width: 731px;
-  }
-  @media screen and (min-width: ${MEDIUM_ENDPOINT}) {
-    padding-left: 0;
-    padding-right: 0;
-    padding-bottom: 2.75rem;
-    padding-top: 2rem;
-  }
-`;
 
 const Title = styled.h1`
   @media screen and (min-width: ${SMALL_ENDPOINT}) {

--- a/packages/mars-theme/src/components/breadcrumbs/index.js
+++ b/packages/mars-theme/src/components/breadcrumbs/index.js
@@ -55,9 +55,7 @@ const Wrapper = styled.div`
   margin-top: 1.25rem;
   font-size: 0.75rem;
   line-height: 1.3125rem;
-  padding: 0;
   @media screen and (max-width: ${MEDIUM_ENDPOINT}) {
-    padding: 0 1rem;
     margin-top: 0;
   }
 `;

--- a/packages/mars-theme/src/components/category/list-name.js
+++ b/packages/mars-theme/src/components/category/list-name.js
@@ -47,11 +47,13 @@ CategoryNameList.propTypes = {
 };
 
 const TitleWrapper = styled.span`
-  margin-right: 1rem;
+  margin-bottom: 25px;
   color: var(--color-medium-grey);
   text-transform: uppercase;
   font-size: 0.75rem;
-  @media screen and (max-width: ${SMALL_ENDPOINT}) {
-    display: block;
+  display: block;
+  @media screen and (min-width: ${SMALL_ENDPOINT}) {
+    margin-right: 20px;
+    display: inline;
   }
 `;

--- a/packages/mars-theme/src/components/category/list-name.js
+++ b/packages/mars-theme/src/components/category/list-name.js
@@ -22,16 +22,15 @@ const CategoryNameList = ({ categories, styles = '', title }) => {
       {title && <TitleWrapper>{title}</TitleWrapper>}
       {categories.map(({ name, link }) => {
         return (
-          <CategoryName key={name + link}>
-            <Link
-              css={css`
-                ${linkCss}
-              `}
-              link={link}
-            >
-              {name}
-            </Link>
-          </CategoryName>
+          <Link
+            css={css`
+              ${linkCss}
+            `}
+            link={link}
+            key={name + link}
+          >
+            <CategoryName>{name}</CategoryName>
+          </Link>
         );
       })}
     </Wrapper>

--- a/packages/mars-theme/src/components/category/name.js
+++ b/packages/mars-theme/src/components/category/name.js
@@ -11,6 +11,7 @@ const CategoryName = ({ children, styles = '' }) => {
     font-weight: 200;
     text-transform: uppercase;
     display: inline-flex;
+    align-items: center;
     margin-right: 1.25rem;
     margin-bottom: 1.25rem;
     height: 1.5rem;

--- a/packages/mars-theme/src/components/category/name.js
+++ b/packages/mars-theme/src/components/category/name.js
@@ -13,7 +13,6 @@ const CategoryName = ({ children, styles = '' }) => {
     display: inline-flex;
     margin-right: 1.25rem;
     margin-bottom: 1.25rem;
-    margin-top: 1rem;
     height: 1.5rem;
     :hover {
       background-color: var(--color-primary);

--- a/packages/mars-theme/src/components/entity-info/index.js
+++ b/packages/mars-theme/src/components/entity-info/index.js
@@ -85,9 +85,7 @@ const Wrapper = styled.div`
   margin-top: 1.1875rem;
   margin-bottom: 1.1875rem;
   width: 100%;
-  padding: 0 1rem;
   @media screen and (min-width: ${MEDIUM_ENDPOINT}) {
-    padding: 0;
     width: 635px;
   }
 `;
@@ -162,7 +160,6 @@ const ArrowDown = styled.div`
 `;
 
 const List = styled.div`
-  padding: 1.75rem 2.5rem;
   border: 1px solid #aaa;
   position: absolute;
   width: 100%;

--- a/packages/mars-theme/src/components/entity-info/index.js
+++ b/packages/mars-theme/src/components/entity-info/index.js
@@ -160,6 +160,7 @@ const ArrowDown = styled.div`
 `;
 
 const List = styled.div`
+  padding: 1.75rem 2.5rem;
   border: 1px solid #aaa;
   position: absolute;
   width: 100%;

--- a/packages/mars-theme/src/components/entity-info/index.js
+++ b/packages/mars-theme/src/components/entity-info/index.js
@@ -5,7 +5,7 @@ import EntityDescription from './description';
 import CategoryList from './category-list';
 import AuthorList from './authors-list';
 import TagList from './tags-list';
-import { MEDIUM_ENDPOINT } from '../heplers/css-endpoints';
+import { SMALL_ENDPOINT, MEDIUM_ENDPOINT } from '../heplers/css-endpoints';
 
 const EntityInfo = ({ state }) => {
   const data = state.source.get(state.router.link);
@@ -160,7 +160,7 @@ const ArrowDown = styled.div`
 `;
 
 const List = styled.div`
-  padding: 1.75rem 2.5rem;
+  padding: 1.25rem 2rem;
   border: 1px solid #aaa;
   position: absolute;
   width: 100%;
@@ -169,4 +169,7 @@ const List = styled.div`
   min-height: 23.75rem;
   max-height: 43rem;
   overflow-y: auto;
+  @media screen and (min-width: ${SMALL_ENDPOINT}) {
+    padding: 1.75rem 2.5rem;
+  }
 `;

--- a/packages/mars-theme/src/components/featured-media.js
+++ b/packages/mars-theme/src/components/featured-media.js
@@ -5,7 +5,6 @@ import Image from '@frontity/components/image';
 
 const FeaturedMedia = ({ state, id, styles = '' }) => {
   const Container = styled.div`
-    margin-top: 1rem;
     height: 200px;
     width: 100%;
     ${styles}

--- a/packages/mars-theme/src/components/index.css
+++ b/packages/mars-theme/src/components/index.css
@@ -19,11 +19,13 @@ a {
     color: var(--color-darkest-grey);
 }
 
-/* a.post-link {
+a.post-link {
     height: 100%;
     width: 100%;
     position: absolute;
-} */
+    top: 0;
+    left: 0;
+}
 
 a.post-link:hover {
     text-decoration: none;

--- a/packages/mars-theme/src/components/index.css
+++ b/packages/mars-theme/src/components/index.css
@@ -19,11 +19,11 @@ a {
     color: var(--color-darkest-grey);
 }
 
-a.post-link {
+/* a.post-link {
     height: 100%;
     width: 100%;
     position: absolute;
-}
+} */
 
 a.post-link:hover {
     text-decoration: none;
@@ -56,49 +56,6 @@ article>.post-link:hover+.feautured-media+.categories-list-wrapper+h1
     color: inherit;
 }
 
-.footer-contact-us .subscribe-btn {
-    width: 299px;
-}
-
 .feautured-media {
     width: 100%;
-}
-
-@media screen and (max-width: 768px) {
-    .footer-contact-us .subscribe-btn {
-        width: 100%;
-    }
-
-    .footer-links-texts, .footer-links-social {
-        display: flex;
-        justify-content: space-between;
-    }
-
-    .c-footer .footer-links .footer-links-texts li {
-        margin-right: 0;
-    }
-}
-
-.footer-logos>p{
-    margin-left: 20px;
-}
-
-.c-header.relative .row {
-    max-width: 1110px;
-}
-
-.c-header.relative .row>div {
-    padding: 0 1rem;
-}
-
-@media screen and (min-width: 1024px) and (max-width: 1110px) {
-    .c-header.relative .row>div {
-        padding: 0 1.5rem;
-    }
-}
-
-@media screen and (min-width: 1110px) {
-    .c-header.relative .row>div {
-        padding: 0;
-    }
 }

--- a/packages/mars-theme/src/components/list/list-item.js
+++ b/packages/mars-theme/src/components/list/list-item.js
@@ -6,7 +6,6 @@ import FeaturedMedia from '../featured-media';
 import CategoryNameList from '../category/list-name';
 import PostTitle from '../post/title';
 import Excerpt from '../post/excerpt';
-import { LARGE_ENDPOINT, MEDIUM_ENDPOINT } from '../heplers/css-endpoints';
 
 /**
  * Item Component
@@ -30,17 +29,10 @@ const Item = ({
   });
 
   const Wrapper = styled.article`
-    width: 31.532%;
     flex-wrap: wrap;
-    margin-bottom: 2.75rem;
     position: relative;
-    @media screen and (max-width: ${LARGE_ENDPOINT}) {
-      width: 49%;
-    }
-    @media screen and (max-width: ${MEDIUM_ENDPOINT}) {
-      width: 100%;
-      padding: 0 1rem;
-    }
+    margin-bottom: 30px;
+    width: 100%;
     ${styles}
   `;
 
@@ -57,25 +49,26 @@ const Item = ({
        * list of featured posts, we render the media.
        */}
       <Link link={item.link} className="post-link">
-        &nbsp;
-      </Link>
-      <div className="feautured-media">
-        {state.theme.featured.showOnList && media && media(item.featured_media)}
-        {state.theme.featured.showOnList && !media && (
-          <FeaturedMedia key={item.featured_media} id={item.featured_media} />
+        <div className="feautured-media">
+          {state.theme.featured.showOnList &&
+            media &&
+            media(item.featured_media)}
+          {state.theme.featured.showOnList && !media && (
+            <FeaturedMedia key={item.featured_media} id={item.featured_media} />
+          )}
+        </div>
+        {/* Show categories of the post */}
+        <CategoryNameList categories={categories} styles="position:relative;" />
+        {/* <Link link={item.link} className="post-title-link"> */}
+        {!title && (
+          <PostTitle styles={titleStyles}>{item.title.rendered}</PostTitle>
         )}
-      </div>
-      {/* Show categories of the post */}
-      <CategoryNameList categories={categories} styles="position:relative;" />
-      {/* <Link link={item.link} className="post-title-link"> */}
-      {!title && (
-        <PostTitle styles={titleStyles}>{item.title.rendered}</PostTitle>
-      )}
-      {title && title(item.title.rendered)}
-      {/* </Link> */}
-      {/* If the post has an excerpt (short summary text), we render it */}
-      {item.excerpt && excerpt && excerpt(item.excerpt.rendered)}
-      {item.excerpt && !excerpt && <Excerpt>{item.excerpt.rendered}</Excerpt>}
+        {title && title(item.title.rendered)}
+        {/* </Link> */}
+        {/* If the post has an excerpt (short summary text), we render it */}
+        {item.excerpt && excerpt && excerpt(item.excerpt.rendered)}
+        {item.excerpt && !excerpt && <Excerpt>{item.excerpt.rendered}</Excerpt>}
+      </Link>
     </Wrapper>
   );
 };

--- a/packages/mars-theme/src/components/list/list-item.js
+++ b/packages/mars-theme/src/components/list/list-item.js
@@ -58,7 +58,10 @@ const Item = ({
           )}
         </div>
         {/* Show categories of the post */}
-        <CategoryNameList categories={categories} styles="position:relative;" />
+        <CategoryNameList
+          categories={categories}
+          styles="position:relative; margin-top: 20px;"
+        />
         {/* <Link link={item.link} className="post-title-link"> */}
         {!title && (
           <PostTitle styles={titleStyles}>{item.title.rendered}</PostTitle>

--- a/packages/mars-theme/src/components/list/list-item.js
+++ b/packages/mars-theme/src/components/list/list-item.js
@@ -48,30 +48,27 @@ const Item = ({
        * If the want to show featured media in the
        * list of featured posts, we render the media.
        */}
-      <Link link={item.link} className="post-link">
-        <div className="feautured-media">
-          {state.theme.featured.showOnList &&
-            media &&
-            media(item.featured_media)}
-          {state.theme.featured.showOnList && !media && (
-            <FeaturedMedia key={item.featured_media} id={item.featured_media} />
-          )}
-        </div>
-        {/* Show categories of the post */}
-        <CategoryNameList
-          categories={categories}
-          styles="position:relative; margin-top: 20px;"
-        />
-        {/* <Link link={item.link} className="post-title-link"> */}
-        {!title && (
-          <PostTitle styles={titleStyles}>{item.title.rendered}</PostTitle>
+      <Link link={item.link} className="post-link" />
+      <div className="feautured-media">
+        {state.theme.featured.showOnList && media && media(item.featured_media)}
+        {state.theme.featured.showOnList && !media && (
+          <FeaturedMedia key={item.featured_media} id={item.featured_media} />
         )}
-        {title && title(item.title.rendered)}
-        {/* </Link> */}
-        {/* If the post has an excerpt (short summary text), we render it */}
-        {item.excerpt && excerpt && excerpt(item.excerpt.rendered)}
-        {item.excerpt && !excerpt && <Excerpt>{item.excerpt.rendered}</Excerpt>}
-      </Link>
+      </div>
+      {/* Show categories of the post */}
+      <CategoryNameList
+        categories={categories}
+        styles="position:relative; margin-top: 20px;"
+      />
+      {/* <Link link={item.link} className="post-title-link"> */}
+      {!title && (
+        <PostTitle styles={titleStyles}>{item.title.rendered}</PostTitle>
+      )}
+      {title && title(item.title.rendered)}
+      {/* </Link> */}
+      {/* If the post has an excerpt (short summary text), we render it */}
+      {item.excerpt && excerpt && excerpt(item.excerpt.rendered)}
+      {item.excerpt && !excerpt && <Excerpt>{item.excerpt.rendered}</Excerpt>}
     </Wrapper>
   );
 };

--- a/packages/mars-theme/src/components/list/list.js
+++ b/packages/mars-theme/src/components/list/list.js
@@ -84,7 +84,7 @@ const List = ({ state }) => {
     }
   }, [page, state, totalPages, posts, setIsFetching, isFetching]);
 
-  const categoriesStyles = `margin-bottom: 0.25rem;`;
+  const categoriesStyles = `margin-bottom: 20px;`;
 
   return (
     <Wrapper>
@@ -163,8 +163,9 @@ const Wrapper = styled.div`
   width: 100%;
   padding-top: 3.125rem;
   padding-bottom: 3.75rem;
-  @media screen and (min-width: ${MEDIUM_ENDPOINT}) {
+  @media screen and (min-width: ${SMALL_ENDPOINT}) {
     padding-bottom: 6.25rem;
+    padding-top: 70px;
   }
 `;
 
@@ -178,6 +179,8 @@ const Divider = styled.div`
 `;
 
 const MainPostWrapper = styled.div`
+  max-width: 1120px;
+  margin: auto;
   @media screen and (min-width: ${SMALL_ENDPOINT}) {
     padding: 0 20px;
   }

--- a/packages/mars-theme/src/components/list/list.js
+++ b/packages/mars-theme/src/components/list/list.js
@@ -84,58 +84,75 @@ const List = ({ state }) => {
     }
   }, [page, state, totalPages, posts, setIsFetching, isFetching]);
 
-  const categoriesStyles = `
-  margin-bottom: 0.25rem;
-  @media screen and (max-width: ${MEDIUM_ENDPOINT}) {
-    padding: 0 1rem;
-  }`;
+  const categoriesStyles = `margin-bottom: 0.25rem;`;
+
   return (
     <Wrapper>
-      <Container>
-        <Breadcrumbs />
-        <EntityInfo />
-        {isBlogHomePage() && <BlogHeader />}
-        {isBlogHomePage() && (
-          <CategoryNameList
-            categories={categories}
-            title="Categories"
-            styles={categoriesStyles}
-          />
-        )}
+      <div className="row">
+        <div className="column small-12">
+          <Breadcrumbs />
+          <EntityInfo />
+          {isBlogHomePage() && <BlogHeader />}
+          {isBlogHomePage() && (
+            <CategoryNameList
+              categories={categories}
+              title="Categories"
+              styles={categoriesStyles}
+            />
+          )}
+        </div>
+      </div>
+      <MainPostWrapper>
         {mainPosts &&
           mainPosts.map(({ type, id }) => {
             const item = state.source[type][id];
             return <MainPost key={item.id} post={item} />;
           })}
+      </MainPostWrapper>
+      <div className="row">
         {subPosts &&
           subPosts.map(({ type, id }) => {
             const item = state.source[type][id];
-            return <SubPost key={item.id} item={item} />;
+            return (
+              <div className="column small-12 medium-6">
+                <SubPost key={item.id} item={item} />
+              </div>
+            );
           })}
-      </Container>
+      </div>
       {isBlogHomePage() && <Divider />}
-      <Container>
-        {isBlogHomePage() && <Title>latest articles</Title>}
-        {/* Iterate over the items of the list. */}
+      {isBlogHomePage() && (
+        <div className="row">
+          <div className="column small-12">
+            <Title>latest articles</Title>
+          </div>
+        </div>
+      )}
+      {/* Iterate over the items of the list. */}
+      <div className="row">
         {posts[state.router.link] &&
           posts[state.router.link].map((el) => {
             if (!el) return null;
             const { type, id } = el;
             const item = state.source[type][id];
             // Render one Item component for each one.
-            return <Item key={item.id + item.date + item.name} item={item} />;
+            return (
+              <div className="column small-12 medium-6 large-4">
+                <Item key={item.id + item.date + item.name} item={item} />
+              </div>
+            );
           })}
-        {posts[state.router.link] &&
-          posts[state.router.link].length % 3 === 2 && <Plug />}
-        {page < totalPages && (
-          <LoadMore
-            isFetching={isFetching}
-            setIsFetching={setIsFetching}
-            setPage={setPage}
-            page={page}
-          />
-        )}
-      </Container>
+      </div>
+      {posts[state.router.link] &&
+        posts[state.router.link].length % 3 === 2 && <Plug />}
+      {page < totalPages && (
+        <LoadMore
+          isFetching={isFetching}
+          setIsFetching={setIsFetching}
+          setPage={setPage}
+          page={page}
+        />
+      )}
     </Wrapper>
   );
 };
@@ -160,29 +177,20 @@ const Divider = styled.div`
   }
 `;
 
-const Container = styled.section`
-  max-width: 1110px;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  margin: 0 auto;
-  list-style: none;
-  @media screen and (min-width: ${MEDIUM_ENDPOINT}) and (max-width: ${LARGE_ENDPOINT}) {
-    padding: 0 1.5rem;
+const MainPostWrapper = styled.div`
+  @media screen and (min-width: ${SMALL_ENDPOINT}) {
+    padding: 0 20px;
   }
 `;
 
 const Title = styled.h3`
   font-size: 1.125rem;
   font-weight: 500;
-  margin-bottom: 2rem;
+  margin-bottom: 50px;
   text-transform: uppercase;
   width: 100%;
   @media screen and (max-width: ${SMALL_ENDPOINT}) {
     display: none;
-  }
-  @media screen and (min-width: ${SMALL_ENDPOINT}) and (max-width: ${MEDIUM_ENDPOINT}) {
-    padding: 0 1rem;
   }
 `;
 

--- a/packages/mars-theme/src/components/list/list.js
+++ b/packages/mars-theme/src/components/list/list.js
@@ -114,8 +114,8 @@ const List = ({ state }) => {
           subPosts.map(({ type, id }) => {
             const item = state.source[type][id];
             return (
-              <div className="column small-12 medium-6">
-                <SubPost key={item.id} item={item} />
+              <div key={item.id} className="column small-12 medium-6">
+                <SubPost item={item} />
               </div>
             );
           })}
@@ -137,8 +137,11 @@ const List = ({ state }) => {
             const item = state.source[type][id];
             // Render one Item component for each one.
             return (
-              <div className="column small-12 medium-6 large-4">
-                <Item key={item.id + item.date + item.name} item={item} />
+              <div
+                key={item.id + item.date + item.name}
+                className="column small-12 medium-6 large-4"
+              >
+                <Item item={item} />
               </div>
             );
           })}

--- a/packages/mars-theme/src/components/list/list.js
+++ b/packages/mars-theme/src/components/list/list.js
@@ -165,7 +165,7 @@ const Wrapper = styled.div`
   padding-bottom: 3.75rem;
   @media screen and (min-width: ${SMALL_ENDPOINT}) {
     padding-bottom: 6.25rem;
-    padding-top: 70px;
+    padding-top: 60px;
   }
 `;
 

--- a/packages/mars-theme/src/components/list/main-post.js
+++ b/packages/mars-theme/src/components/list/main-post.js
@@ -33,10 +33,14 @@ const MainPost = ({ post, state }) => {
     }`;
 
   const mediaStyles = `
-    height: 500px;
+    height: 440px;
+    @media screen and (max-width: ${SMALL_ENDPOINT}) {
+      height: 420px;
+    }
     @media screen and (max-width: ${MEDIUM_ENDPOINT}) {
       height: 400px;
-    }`;
+    }
+  `;
 
   const Wrapper = styled.article`
     margin-bottom: 40px;
@@ -51,9 +55,10 @@ const MainPost = ({ post, state }) => {
     top: 0;
     padding: 30px 16px;
     @media screen and (min-width: ${SMALL_ENDPOINT}) {
-      padding: 50px 70px;
+      padding: 40px 50px;
     }
     @media screen and (min-width: ${MEDIUM_ENDPOINT}) {
+      padding: 50px 70px;
       width: 67%;
     }
     ${mediaStyles}

--- a/packages/mars-theme/src/components/list/main-post.js
+++ b/packages/mars-theme/src/components/list/main-post.js
@@ -33,45 +33,40 @@ const MainPost = ({ post, state }) => {
     }`;
 
   const mediaStyles = `
-    height: 400px;
-    @media screen and (max-width: ${LARGE_ENDPOINT}) {
-        height: 300px;
-    }
+    height: 500px;
     @media screen and (max-width: ${MEDIUM_ENDPOINT}) {
-      height: 500px;
+      height: 400px;
     }`;
 
   const Wrapper = styled.article`
-    margin-bottom: 1.5rem;
+    margin-bottom: 40px;
     ${styles}
   `;
 
   const ContentWrapper = styled.div`
-    height: 100%;
     position: absolute;
     display: flex;
-    align-items: flex-end;
-    flex-flow: wrap;
+    justify-content: flex-end;
+    flex-direction: column;
     top: 0;
-    padding: 0 1rem;
+    padding: 30px 16px;
+    @media screen and (min-width: ${SMALL_ENDPOINT}) {
+      padding: 50px 70px;
+    }
     @media screen and (min-width: ${MEDIUM_ENDPOINT}) {
-      padding: 0 4.375rem;
       width: 67%;
-      align-items: center;
     }
+    ${mediaStyles}
   `;
+
   const TitleStyles = `
-    @media screen and (min-width: ${MEDIUM_ENDPOINT}) {
-      padding-bottom: 2rem;
-    }
     @media screen and (min-width: ${SMALL_ENDPOINT}) {
       font-size: 2rem;
     }
     font-size: 1.875rem;
-    padding-top: 0;
-    padding-bottom: 1.875rem;
     line-height: 1.25;
     color: var(--color-white);
+    margin-bottom: 20px;
   `;
 
   const ExcerptStyles = `
@@ -84,33 +79,28 @@ const MainPost = ({ post, state }) => {
 
   const CategoriesStyles = `
     position: relative;
-    margin-top: 2rem;
     z-index: 2;
   `;
 
   return (
     <Wrapper>
-      <FeaturedMedia id={item.featured_media} styles={mediaStyles} />
-      <ContentWrapper>
-        <Link
-          link={item.link}
-          css={css`
-            width: 100%;
-            height: 100%;
-            position: absolute;
-            z-index: 1;
-          `}
-        >
-          &nbsp;
-        </Link>
-        <div>
+      <Link
+        link={item.link}
+        css={css`
+          width: 100%;
+          height: 100%;
+          z-index: 1;
+        `}
+      >
+        <FeaturedMedia id={item.featured_media} styles={mediaStyles} />
+        <ContentWrapper>
           <CategoryNameList categories={categories} styles={CategoriesStyles} />
           <PostTitle styles={TitleStyles}>{item.title.rendered}</PostTitle>
           <PostExcerpt styles={ExcerptStyles} noHellip>
             {item.excerpt.rendered}
           </PostExcerpt>
-        </div>
-      </ContentWrapper>
+        </ContentWrapper>
+      </Link>
     </Wrapper>
   );
 };

--- a/packages/mars-theme/src/components/list/main-post.js
+++ b/packages/mars-theme/src/components/list/main-post.js
@@ -89,23 +89,21 @@ const MainPost = ({ post, state }) => {
 
   return (
     <Wrapper>
+      <FeaturedMedia id={item.featured_media} styles={mediaStyles} />
       <Link
         link={item.link}
+        className="post-link"
         css={css`
-          width: 100%;
-          height: 100%;
           z-index: 1;
         `}
-      >
-        <FeaturedMedia id={item.featured_media} styles={mediaStyles} />
-        <ContentWrapper>
-          <CategoryNameList categories={categories} styles={CategoriesStyles} />
-          <PostTitle styles={TitleStyles}>{item.title.rendered}</PostTitle>
-          <PostExcerpt styles={ExcerptStyles} noHellip>
-            {item.excerpt.rendered}
-          </PostExcerpt>
-        </ContentWrapper>
-      </Link>
+      />
+      <ContentWrapper>
+        <CategoryNameList categories={categories} styles={CategoriesStyles} />
+        <PostTitle styles={TitleStyles}>{item.title.rendered}</PostTitle>
+        <PostExcerpt styles={ExcerptStyles} noHellip>
+          {item.excerpt.rendered}
+        </PostExcerpt>
+      </ContentWrapper>
     </Wrapper>
   );
 };

--- a/packages/mars-theme/src/components/list/sub-post.js
+++ b/packages/mars-theme/src/components/list/sub-post.js
@@ -5,22 +5,12 @@ import Item from './list-item';
 import FeaturedMedia from '../featured-media';
 import Excerpt from '../post/excerpt';
 import PostTitle from '../post/title';
-import {
-  LARGE_ENDPOINT,
-  MEDIUM_ENDPOINT,
-  SMALL_ENDPOINT,
-} from '../heplers/css-endpoints';
+import { MEDIUM_ENDPOINT, SMALL_ENDPOINT } from '../heplers/css-endpoints';
 
 const SubPost = ({ item }) => {
   const styles = `
-    width: 48.74%;
     flex-wrap: wrap;
-    @media screen and (max-width: ${LARGE_ENDPOINT}) {
-      width: 100%;
-    }
-    @media screen and (max-width: ${SMALL_ENDPOINT}) {
-      width: 100%;
-    }`;
+    width: 100%;`;
 
   const mediaStyles = `
     height: 300px;

--- a/packages/mars-theme/src/components/post.js
+++ b/packages/mars-theme/src/components/post.js
@@ -31,39 +31,43 @@ const Post = ({ state, actions, libraries }) => {
 
   // Load the post, but only if the data is ready.
   return data.isReady ? (
-    <Container id="post-content">
-      <Breadcrumbs />
-      <div>
-        <Title dangerouslySetInnerHTML={{ __html: post.title.rendered }} />
-
-        {/* Only display author and date on posts */}
-        {data.isPost && (
+    <Container>
+      <div className="row" id="post-content">
+        <div className="column small-12">
+          <Breadcrumbs />
           <div>
-            {author && (
-              <StyledLink link={author.link}>
-                <Author>
-                  By <b>{author.name}</b>
-                </Author>
-              </StyledLink>
+            <Title dangerouslySetInnerHTML={{ __html: post.title.rendered }} />
+
+            {/* Only display author and date on posts */}
+            {data.isPost && (
+              <div>
+                {author && (
+                  <StyledLink link={author.link}>
+                    <Author>
+                      By <b>{author.name}</b>
+                    </Author>
+                  </StyledLink>
+                )}
+                <Fecha>
+                  {" "}
+                  on <b>{date.toDateString()}</b>
+                </Fecha>
+              </div>
             )}
-            <Fecha>
-              {" "}
-              on <b>{date.toDateString()}</b>
-            </Fecha>
           </div>
-        )}
+
+          {/* Look at the settings to see if we should include the featured image */}
+          {state.theme.featured.showOnPost && (
+            <FeaturedMedia id={post.featured_media} />
+          )}
+
+          {/* Render the content using the Html2React component so the HTML is processed
+          by the processors we included in the libraries.html2react.processors array. */}
+          <Content>
+            <Html2React html={post.content.rendered} />
+          </Content>
+        </div>
       </div>
-
-      {/* Look at the settings to see if we should include the featured image */}
-      {state.theme.featured.showOnPost && (
-        <FeaturedMedia id={post.featured_media} />
-      )}
-
-      {/* Render the content using the Html2React component so the HTML is processed
-       by the processors we included in the libraries.html2react.processors array. */}
-      <Content>
-        <Html2React html={post.content.rendered} />
-      </Content>
     </Container>
   ) : null;
 };
@@ -71,9 +75,7 @@ const Post = ({ state, actions, libraries }) => {
 export default connect(Post);
 
 const Container = styled.div`
-  width: 800px;
-  margin: 0;
-  padding: 24px;
+  margin: 40px 0;
 `;
 
 const Title = styled.h1`


### PR DESCRIPTION
Updates the currently developed views to use the standard gfw css grid from the `gfw-component` global styles.

- remove ad hoc padding across styled components
- wrap elements in `row`, `column` and `small-12, medium-6 etc...` classNames
- Fix interactivity issues with category tags only clickable on text and not whole button
- fixes overflow issue with absolute positioning of `<Link />` components on cards and featured image breaking the max width of the blog home page
- updates some padding that were broken by the introduction of the new grid
- removes overwriting styles ofr header and footer as they should be managed by the `gfw-components` library